### PR TITLE
Add cancel order button on payment success

### DIFF
--- a/App/Http/Controllers/OrderCancelController.php
+++ b/App/Http/Controllers/OrderCancelController.php
@@ -30,4 +30,46 @@ class OrderCancelController extends Controller
             return back()->with('error', 'Đã xảy ra lỗi khi huỷ đơn hàng.');
         }
     }
+
+    /**
+     * Cancel an order stored in session-based order history.
+     */
+    public function cancelSession(Request $request)
+    {
+        $validated = $request->validate([
+            'order_id' => 'required'
+        ]);
+
+        $targetOrderId = $validated['order_id'];
+
+        $orders = $request->session()->get('order_history', []);
+
+        $foundIndex = null;
+        foreach ($orders as $index => $order) {
+            if (($order['order_id'] ?? null) === $targetOrderId) {
+                $foundIndex = $index;
+                // Only allow cancel if status is 0 (pending)
+                if (isset($order['status']) && (int)$order['status'] !== 0) {
+                    return back()->with('error', 'Không thể huỷ đơn hàng. Đơn đã được xử lý.');
+                }
+                break;
+            }
+        }
+
+        if ($foundIndex === null) {
+            return back()->with('error', 'Không tìm thấy đơn hàng để huỷ.');
+        }
+
+        // Remove the order from session history
+        array_splice($orders, $foundIndex, 1);
+        $request->session()->put('order_history', array_values($orders));
+
+        // If the current order_data matches, remove it as well
+        $orderData = $request->session()->get('order_data');
+        if (is_array($orderData) && (($orderData['order_id'] ?? null) === $targetOrderId)) {
+            $request->session()->forget('order_data');
+        }
+
+        return redirect()->route('cart.history')->with('success', 'Huỷ đơn hàng thành công!');
+    }
 }

--- a/App/Http/Controllers/PaymentController.php
+++ b/App/Http/Controllers/PaymentController.php
@@ -59,6 +59,7 @@ class PaymentController extends Controller
         }
 
         // 4. Chuẩn bị dữ liệu đơn hàng
+        $generatedOrderId = 'ORD-' . time();
         $orderData = [
             'full_name' => $request->input('full_name'),
             'email' => $request->input('email'),
@@ -67,6 +68,8 @@ class PaymentController extends Controller
             'payment_method' => $request->input('payment_method'),
             'total_amount' => $totalAmount,
             'order_date' => now(),
+            // Lưu kèm mã đơn hàng để hủy ở trang success
+            'order_id' => $generatedOrderId,
         ];
 
         // 5. Xử lý đơn hàng (giả lập thành công)
@@ -109,10 +112,10 @@ class PaymentController extends Controller
             // Thêm đơn hàng vào lịch sử đơn hàng trong session
             $orderHistory = $request->session()->get('order_history', []);
             $orderHistory[] = [
-                'order_id' => 'ORD-' . time(), // Generate a simple order ID
+                'order_id' => $generatedOrderId, // Generate a simple order ID
                 'created_at' => now(),
                 'total' => $totalAmount,
-                'status' => 1, // 1 = Đã giao hàng (simulated)
+                'status' => 0, // 0 = Chờ xử lý (cho phép huỷ)
                 'payment_data' => $orderData,
                 'items' => $cart
             ];

--- a/resources/views/payment/success.blade.php
+++ b/resources/views/payment/success.blade.php
@@ -76,6 +76,16 @@
             <a href="{{ route('cart.history') }}" class="btn btn-outline-secondary btn-lg">
                 📋 Xem lịch sử đơn hàng
             </a>
+            @if(session('order_data.order_id'))
+            <form action="{{ route('orders.cancel.session') }}" method="POST" class="d-inline-block ms-3"
+                onsubmit="return confirm('Bạn có chắc muốn huỷ đơn hàng này?');">
+                @csrf
+                <input type="hidden" name="order_id" value="{{ session('order_data.order_id') }}">
+                <button type="submit" class="btn btn-danger btn-lg">
+                    ❌ Huỷ đơn hàng
+                </button>
+            </form>
+            @endif
         </div>
 
         <div class="mt-5">

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,6 +50,7 @@ Route::get('/payment/success', [PaymentController::class, 'showSuccess'])->name(
 // Lịch sử đơn hàng
 Route::get('/purchase-history', [OrderHistoryController::class, 'index'])->name('cart.history');
 Route::post('/orders/cancel', [OrderCancelController::class, 'cancel'])->name('orders.cancel')->middleware('auth');
+Route::post('/orders/cancel-session', [OrderCancelController::class, 'cancelSession'])->name('orders.cancel.session');
 
 // Liên hệ
 Route::get('/lien-he', [ContactController::class, 'show'])->name('lien-he');


### PR DESCRIPTION
Add a "Cancel Order" button to the payment success page to allow users to cancel newly placed, pending orders.

The existing order flow immediately marked orders as "delivered" (status 1), preventing cancellation. This change introduces a "pending" status (status 0) for new orders and a mechanism to cancel them from the success page, improving user flexibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-3fc30a1e-9585-4ed4-add7-029f1e0c9461">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3fc30a1e-9585-4ed4-add7-029f1e0c9461">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

